### PR TITLE
Major refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.35.1", features = ["full"] }
 regex = "1.10.2"
 lazy_static = "1.4.0"
 scraper = "0.18.1"
+dashmap = "5.5.3"
 
 [[bin]]
 name = "webstrings"

--- a/src/http.rs
+++ b/src/http.rs
@@ -6,8 +6,9 @@ pub struct HttpResponse {
     pub body: String,
 }
 
-pub async fn get(url: &String) -> Result<HttpResponse, reqwest::Error> {
-    let res = reqwest::Client::new()
+pub async fn get(url: &String, client: &reqwest::Client) -> Result<HttpResponse, reqwest::Error> {
+    let res = client
+        .clone()
         .get(url)
         .header(
             USER_AGENT,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,6 @@
 use clap::Parser;
-use std::collections::HashSet;
-use std::{
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
-use tokio::sync::Mutex;
+use dashmap::DashMap;
+use std::time::Duration;
 
 mod js;
 mod links;
@@ -28,7 +21,7 @@ struct Args {
 
     //TODO add output file functionality
     /// Number of concurrent requests, with 10 being the default
-    #[arg(short = 't', long = "threads", default_value = "10")]
+    #[arg(short = 't', long = "threads", default_value = "25")]
     threads: usize,
 
     /// Debug mode
@@ -51,112 +44,152 @@ struct Args {
     url: Option<String>,
 }
 
-async fn process_url(
-    url: &String,
+struct WorkerOptions {
     debug: bool,
     urls: bool,
     secrets: bool,
     cite: bool,
     noisy: bool,
-) -> Vec<String> {
+}
+
+// TODO: Each worker needs to output results to either an mpsc channel with a thread collecting results into findings_map and errors, or directly into findings_map and sending errors to stderr
+async fn process_url(
+    url: &String,
+    options: &WorkerOptions,
+    client: &reqwest::Client,
+    output: tokio::sync::mpsc::Sender<String>,
+) {
     let mut new_urls = Vec::new();
 
-    let res = match http::get(url).await {
+    let res = match http::get(url, client).await {
         Ok(res) => res,
         Err(e) => {
-            if debug {
-                eprintln!("[WARN] Failed to get {}: {}", url, e);
+            if options.debug {
+                let message = format!("[WARN] Failed to get {}: {}", url, e);
+                output
+                    .clone()
+                    .send(message)
+                    .await
+                    .expect("Worker failed to send output");
             }
-            return new_urls;
+            return;
         }
     };
 
     if !(res.status.is_success()) {
-        if debug {
-            eprintln!("[WARN] Failed to get {}: {}", url, res.status);
+        if options.debug {
+            let message = format!("[WARN] Failed to get {}: {}", url, res.status);
+            output
+                .clone()
+                .send(message)
+                .await
+                .expect("Worker failed to send output");
         }
-        return new_urls;
+        return;
     }
 
-    if debug {
-        eprintln!("[INFO] Url: {}", url);
-        eprintln!("[INFO] Status: {}", res.status);
-        //println!("Headers:\n{:#?}", res.headers);
-        //println!("Body:\n{}", res.body);
+    if options.debug {
+        let message = format!("[INFO] Url: {}\n [INFO] Status: {}", url, res.status);
+        output
+            .clone()
+            .send(message)
+            .await
+            .expect("Worker failed to send output");
     }
 
-    if urls {
-        for link in get_links(&res, url).iter() {
-            println!("{}", link);
-            new_urls.push(link.to_string());
+    // Get URLs from the page and sources
+    for link in get_links(&res, url).iter() {
+        if options.urls {
+            let message = format!("{}", link);
+            output
+                .clone()
+                .send(message)
+                .await
+                .expect("Worker failed to send output");
+        }
+        new_urls.push(link.to_string());
+    }
+    for source in get_script_sources(&res, url)
+        .expect("get_script_sources error")
+        .iter()
+    {
+        new_urls.push(source.to_string());
+    }
+
+    // Get either secrets or strings
+    if options.secrets {
+        for link in secrets::get_header_secrets(&res, options.noisy) {
+            let message: String;
+            if options.cite {
+                message = format!("{} (Location: {})", link, url); //TODO Find a way to remove duplicate findings, despite being found in different tasks
+            } else {
+                message = format!("{}", link);
+            }
+            output
+                .clone()
+                .send(message)
+                .await
+                .expect("Worker failed to send output");
+        }
+        for link in secrets::get_secrets(&res, options.noisy) {
+            let message: String;
+            if options.cite {
+                message = format!("{} (Location: {})", link, url); //TODO Find a way to remove duplicate findings, despite being found in different tasks
+            } else {
+                message = format!("{}", link);
+            }
+            output
+                .clone()
+                .send(message)
+                .await
+                .expect("Worker failed to send output");
         }
     } else {
-        if secrets {
-            secrets::get_header_secrets(&res, noisy)
-                .iter()
-                .for_each(|link| {
-                    if cite {
-                        println!("{} (Location: {})", link, url); //TODO Find a way to remove duplicate findings, despite being found in different tasks
-                    } else {
-                        println!("{}", link)
-                    }
-                });
-            secrets::get_secrets(&res, noisy).iter().for_each(|link| {
-                if cite {
-                    println!("{} (Location: {})", link, url);
+        if url.ends_with(".js") {
+            for string in js::extract_strings(&res.body) {
+                let message: String;
+                if options.cite {
+                    message = format!("{} (Location: {})", string, url); //TODO Find a way to remove duplicate findings, despite being found in different tasks
                 } else {
-                    println!("{}", link)
+                    message = format!("{}", string);
                 }
-            });
-        } else {
-            if url.ends_with(".js") {
-                js::extract_strings(&res.body).iter().for_each(|string| {
-                    if cite {
-                        println!("{} (Location: {})", string, url);
-                    } else {
-                        println!("{}", string);
-                    }
-                });
+                output
+                    .clone()
+                    .send(message)
+                    .await
+                    .expect("Worker failed to send output");
             }
-            js::get_scripts(&res)
-                .expect("Failed to get scripts")
-                .iter()
-                .for_each(|script| {
-                    js::extract_strings(script).iter().for_each(|string| {
-                        if cite {
-                            println!("{} (Location: {})", string, url);
-                        } else {
-                            println!("{}", string);
-                        }
-                    });
-                });
         }
-
-        for link in get_links(&res, url).iter() {
-            new_urls.push(link.to_string());
-        }
-
-        for source in get_script_sources(&res, url)
-            .expect("get_script_sources error")
-            .iter()
+        for string in js::get_scripts(&res)
+            .expect("Failed to get scripts")
+            .iter() // Assuming get_scripts returns a Vec or similar collection
+            .flat_map(|script| js::extract_strings(script))
         {
-            new_urls.push(source.to_string());
+            let message: String;
+            if options.cite {
+                message = format!("{} (Location: {})", string, url); //TODO Find a way to remove duplicate findings, despite being found in different tasks
+            } else {
+                message = format!("{}", string);
+            }
+            output
+                .clone()
+                .send(message)
+                .await
+                .expect("Worker failed to send output");
         }
     }
-
-    new_urls
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
 
-    // Create a multi-producer single-consumer (mpsc) channel for the URLs
-    let (url_sender, mut url_receiver) = tokio::sync::mpsc::channel(100);
-    let url_sender = Arc::new(Mutex::new(url_sender));
-    let sent_messages = Arc::new(Mutex::new(HashSet::new()));
+    let url_map: DashMap<String, bool> = DashMap::new(); // Using a concurrent hashmap to avoid duplicates and race conditions
+    let (output_sender, output_receiver) = tokio::sync::mpsc::channel(args.threads);
+    let finding_map: DashMap<String, String> = DashMap::new();
 
-    let urls = if let Some(file) = args.file {
+    // Parse input and add to url_map
+    if let Some(file) = args.file {
         std::fs::read_to_string(file)
             .expect("Failed to read file")
             .lines()
@@ -167,15 +200,15 @@ async fn main() {
                     format!("https://{}", line)
                 }
             })
-            .collect::<Vec<_>>()
+            .for_each(|url| {
+                url_map.insert(url, false);
+            });
     } else if let Some(url) = args.url {
-        vec![
-            if url.starts_with("http://") || url.starts_with("https://") {
-                url
-            } else {
-                format!("https://{}", url)
-            },
-        ]
+        if url.starts_with("http://") || url.starts_with("https://") {
+            url_map.insert(url, false);
+        } else {
+            url_map.insert(format!("https://{}", url), false);
+        }
     } else {
         // Print help message if no URL or file is provided
         match Args::try_parse_from(["webscan", "-h"]) {
@@ -184,95 +217,64 @@ async fn main() {
         };
     };
 
-    let url_sender_clone = Arc::clone(&url_sender);
-    for url in urls {
-        {
-            let sender = url_sender.lock().await;
-            let mut sent_messages = sent_messages.lock().await;
-            if !sent_messages.contains(url.as_str()) {
-                sent_messages.insert(url.clone());
-                match sender.send(url).await {
-                    Ok(_) => (),
-                    Err(e) => eprintln!("Unable to send url to channel: {}", e),
-                }
-            } else {
-                continue;
-            }
-        }
+    // Create a single producer single concumer channel for each thread that the orchestration thread will use to give them tasks
+    let mut senders = Vec::with_capacity(args.threads);
+    let mut receivers = Vec::with_capacity(args.threads);
+    for _ in 0..args.threads {
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        senders.push(Some(tx));
+        receivers.push(rx);
     }
-    //Drop the channel now that the original urls are done being sent
-    drop(url_sender_clone);
 
-    let mut tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-    let active_tasks = Arc::new(AtomicUsize::new(0));
+    // Spawn a thread for each channel (args.threads num of threads), and have them process any URLs sent the the channels until the channels are closed
+    for (_, mut receiver) in receivers.into_iter().enumerate() {
+        let output_sender_clone = output_sender.clone();
+        let options = WorkerOptions {
+            debug: args.debug,
+            urls: args.urls,
+            secrets: args.secrets,
+            cite: args.cite,
+            noisy: args.all,
+        };
+        let http_client = reqwest::Client::new();
+        tokio::spawn(async move {
+            while let Ok(url) = receiver.try_recv() {
+                let url_clone = url.clone();
+                process_url(
+                    &url_clone,
+                    &options,
+                    &http_client,
+                    output_sender_clone.clone(),
+                )
+                .await;
+            }
+        });
+    }
 
+    // Orchestration thread will send URLs to each thread and close the channels after the URLs map has been empty for a series of sleep periods
+    let mut counter = 0;
+    let mut index = 0;
     loop {
-        tokio::time::sleep(Duration::from_millis(100)).await; //Avoid race conditions
-        let url_option = url_receiver.try_recv();
-        if active_tasks.load(Ordering::Relaxed) == 0 && url_option.is_err() {
-            drop(url_sender);
+        if let Some(entry) = url_map.iter().find(|entry| !*entry.value()) {
+            let url = entry.key().clone();
+            url_map.insert(url.clone(), true);
+            if let Some(sender_opt) = senders.get_mut(index % args.threads) {
+                if let Some(sender) = sender_opt.take() {
+                    let _ = sender.send(url.to_string());
+                }
+            }
+            counter = 0;
+            index += 1;
+        } else {
+            counter += 1;
+            let sleep_duration = Duration::from_secs(1 << counter);
+            tokio::time::sleep(sleep_duration).await;
+        }
+
+        // If the counter reaches 5 sleep periods with no URLs, close the worker threads and exit.
+        if counter >= 5 {
+            senders.clear();
             break;
-        }
-
-        match url_option {
-            Ok(url) => {
-                let url_sender = Arc::clone(&url_sender);
-                let active_tasks = Arc::clone(&active_tasks);
-                let sent_messages = Arc::clone(&sent_messages);
-
-                active_tasks.fetch_add(1, Ordering::Relaxed);
-                let task = tokio::spawn(async move {
-                    let new_urls = process_url(
-                        &url,
-                        args.debug,
-                        args.urls,
-                        args.secrets,
-                        args.cite,
-                        args.all,
-                    )
-                    .await;
-                    if new_urls.is_empty() {
-                        active_tasks.fetch_sub(1, Ordering::Relaxed);
-                    } else {
-                        for new_url in new_urls {
-                            {
-                                let sender = url_sender.lock().await;
-                                let mut sent_messages = sent_messages.lock().await;
-                                if !sent_messages.contains(new_url.as_str()) {
-                                    sent_messages.insert(new_url.clone());
-                                    match sender.send(new_url).await {
-                                        Ok(_) => (),
-                                        Err(e) => {
-                                            eprintln!("Task unable to send url to channel: {}", e)
-                                        }
-                                    }
-                                } else {
-                                    continue;
-                                }
-                            }
-                        }
-
-                        active_tasks.fetch_sub(1, Ordering::Relaxed);
-                    }
-                });
-
-                tasks.push(task);
-            }
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
-                // Wait a bit and try again
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
-                eprintln!("Error: Channel disconnected");
-                break;
-            }
-        }
-    }
-
-    for task in tasks {
-        match task.await {
-            Ok(_) => (),
-            Err(e) => eprintln!("A task panicked: {:?}", e),
         }
     }
 }


### PR DESCRIPTION
- Use hashmaps and hashsets to prevent duplicates that were leading to infinite loops
- Added depth limit to allow for shorter scans, with a --depth flag to set the amount
- Formatted code and made it much more legible, especially with regard to the concurrency
- Threads now reuse HTTP clients as well
- Added timer and loading spinner flags